### PR TITLE
Make .elfinder-contextmenu more specific.

### DIFF
--- a/moono/css/contextmenu.less
+++ b/moono/css/contextmenu.less
@@ -1,45 +1,47 @@
-.elfinder-contextmenu * {
-  font: normal normal normal 16px Arial,Helvetica,Tahoma,Verdana,Sans-Serif;
-}
+.elfinder {
+  .elfinder-contextmenu * {
+    font: normal normal normal 16px Arial,Helvetica,Tahoma,Verdana,Sans-Serif;
+  }
 
-.elfinder-contextmenu {
-  display: block;
-  border: 1px solid #b6b6b6;
-  padding: 0;
-  box-shadow: 0 0 3px rgba(0,0,0,.15);
-}
+  .elfinder-contextmenu {
+    display: block;
+    border: 1px solid #b6b6b6;
+    padding: 0;
+    box-shadow: 0 0 3px rgba(0,0,0,.15);
+  }
 
-/* item */
-.elfinder-contextmenu .elfinder-contextmenu-item {
-  padding: 5px 30px 5px 30px;
-  box-sizing: border-box;
-  height: 24px;
-}
+  /* item */
+  .elfinder-contextmenu .elfinder-contextmenu-item {
+    padding: 5px 30px 5px 30px;
+    box-sizing: border-box;
+    height: 24px;
+  }
 
-/* item hovered */
-.elfinder-contextmenu .elfinder-contextmenu-item:hover {
-  background-color: #EFF0EF;
-}
+  /* item hovered */
+  .elfinder-contextmenu .elfinder-contextmenu-item:hover {
+    background-color: #EFF0EF;
+  }
 
-/* icons */
-.elfinder-contextmenu .elfinder-contextmenu-icon {
-  top: 0;
-  left: 0;
-  margin: 0;
-  background-color: #D7D8D7;
-  opacity: 0.70; /* Safari, Opera and Mozilla */
-  filter: alpha(opacity=70); /* IE */
-  height: 100%;
-  line-height: 24px;
-  width: 24px;
-  text-align: center;
-}
+  /* icons */
+  .elfinder-contextmenu .elfinder-contextmenu-icon {
+    top: 0;
+    left: 0;
+    margin: 0;
+    background-color: #D7D8D7;
+    opacity: 0.70; /* Safari, Opera and Mozilla */
+    filter: alpha(opacity=70); /* IE */
+    height: 100%;
+    line-height: 24px;
+    width: 24px;
+    text-align: center;
+  }
 
-/* separator */
-.elfinder-contextmenu .elfinder-contextmenu-separator {
-  border: none;
-  background-color: #D3D3D3;
-  height: 1px;
-  filter: alpha(opacity=70); /* IE */
-  opacity: 0.70; /* Safari, Opera and Mozilla */
+  /* separator */
+  .elfinder-contextmenu .elfinder-contextmenu-separator {
+    border: none;
+    background-color: #D3D3D3;
+    height: 1px;
+    filter: alpha(opacity=70); /* IE */
+    opacity: 0.70; /* Safari, Opera and Mozilla */
+  }
 }


### PR DESCRIPTION
In newer versions of elfinder the default CSS is more specific and to the changes in this skin don’t get picked up. This makes the skin more specific as well so they override the default CSS.
